### PR TITLE
Upgrade Civix files

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -26,5 +26,9 @@
   </classloader>
   <civix>
     <namespace>CRM/Selfservice</namespace>
+    <format>22.05.2</format>
   </civix>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/mixin/menu-xml@1.0.0.mixin.php
+++ b/mixin/menu-xml@1.0.0.mixin.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Auto-register "xml/Menu/*.xml" files.
+ *
+ * @mixinName menu-xml
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::xmlMenu()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_xmlMenu', function ($e) use ($mixInfo) {
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $files = (array) glob($mixInfo->getPath('xml/Menu/*.xml'));
+    foreach ($files as $file) {
+      $e->files[] = $file;
+    }
+  });
+
+};

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[__FUNCTION__][$mixin])) {
+      \Civi::$statics[__FUNCTION__][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};

--- a/selfservice.civix.php
+++ b/selfservice.civix.php
@@ -79,6 +79,13 @@ class CRM_Selfservice_ExtensionUtil {
 
 use CRM_Selfservice_ExtensionUtil as E;
 
+function _selfservice_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
@@ -91,9 +98,9 @@ function _selfservice_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {
@@ -105,19 +112,7 @@ function _selfservice_civix_civicrm_config(&$config = NULL) {
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function _selfservice_civix_civicrm_xmlMenu(&$files) {
-  foreach (_selfservice_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  _selfservice_civix_mixin_polyfill();
 }
 
 /**
@@ -130,6 +125,7 @@ function _selfservice_civix_civicrm_install() {
   if ($upgrader = _selfservice_civix_upgrader()) {
     $upgrader->onInstall();
   }
+  _selfservice_civix_mixin_polyfill();
 }
 
 /**
@@ -170,6 +166,7 @@ function _selfservice_civix_civicrm_enable() {
       $upgrader->onEnable();
     }
   }
+  _selfservice_civix_mixin_polyfill();
 }
 
 /**
@@ -215,136 +212,6 @@ function _selfservice_civix_upgrader() {
   else {
     return CRM_Selfservice_Upgrader_Base::instance();
   }
-}
-
-/**
- * Search directory tree for files which match a glob pattern.
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: Delegate to CRM_Utils_File::findFiles(), this function kept only
- * for backward compatibility of extension code that uses it.
- *
- * @param string $dir base dir
- * @param string $pattern , glob pattern, eg "*.txt"
- *
- * @return array
- */
-function _selfservice_civix_find_files($dir, $pattern) {
-  return CRM_Utils_File::findFiles($dir, $pattern);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function _selfservice_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _selfservice_civix_find_files(__DIR__, '*.mgd.php');
-  sort($mgdFiles);
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function _selfservice_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_selfservice_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = [
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    ];
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function _selfservice_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _selfservice_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_themes().
- *
- * Find any and return any files matching "*.theme.php"
- */
-function _selfservice_civix_civicrm_themes(&$themes) {
-  $files = _selfservice_civix_glob(__DIR__ . '/*.theme.php');
-  foreach ($files as $file) {
-    $themeMeta = include $file;
-    if (empty($themeMeta['name'])) {
-      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
-    }
-    if (empty($themeMeta['ext'])) {
-      $themeMeta['ext'] = E::LONG_NAME;
-    }
-    $themes[$themeMeta['name']] = $themeMeta;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- *
- * @return array
- */
-function _selfservice_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : [];
 }
 
 /**
@@ -426,18 +293,6 @@ function _selfservice_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentI
     if (isset($nodes[$origKey]['child']) && is_array($nodes[$origKey]['child'])) {
       _selfservice_civix_fixNavigationMenuItems($nodes[$origKey]['child'], $maxNavID, $nodes[$origKey]['attributes']['navID']);
     }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function _selfservice_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
-    $metaDataFolders[] = $settingsDir;
   }
 }
 

--- a/selfservice.php
+++ b/selfservice.php
@@ -45,7 +45,6 @@ function selfservice_civicrm_tokenValues(&$values, $cids, $job = null, $tokens =
   CRM_Selfservice_HashLinks::tokenValues($values, $cids, $job, $tokens, $context);
 }
 
-
 /**
  * Set permissions for runner/engine API call
  */
@@ -88,15 +87,6 @@ function selfservice_civicrm_permission(&$permissions) {
  */
 function selfservice_civicrm_config(&$config) {
   _selfservice_civix_civicrm_config($config);
-}
-
-/**
- * Implements hook_civicrm_xmlMenu().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
- */
-function selfservice_civicrm_xmlMenu(&$files) {
-  _selfservice_civix_civicrm_xmlMenu($files);
 }
 
 /**
@@ -154,54 +144,6 @@ function selfservice_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
 }
 
 /**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
- */
-function selfservice_civicrm_managed(&$entities) {
-  _selfservice_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
- */
-function selfservice_civicrm_caseTypes(&$caseTypes) {
-  _selfservice_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
- */
-function selfservice_civicrm_angularModules(&$angularModules) {
-  _selfservice_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
- */
-function selfservice_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _selfservice_civix_civicrm_alterSettingsFolders($metaDataFolders);
-}
-
-/**
  * Implements hook_civicrm_entityTypes().
  *
  * Declare entity types provided by this module.
@@ -212,13 +154,6 @@ function selfservice_civicrm_entityTypes(&$entityTypes) {
   _selfservice_civix_civicrm_entityTypes($entityTypes);
 }
 
-/**
- * Implements hook_civicrm_thems().
- */
-function selfservice_civicrm_themes(&$themes) {
-  _selfservice_civix_civicrm_themes($themes);
-}
-
 // --- Functions below this ship commented out. Uncomment as required. ---
 
 /**
@@ -226,9 +161,8 @@ function selfservice_civicrm_themes(&$themes) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
  *
-function selfservice_civicrm_preProcess($formName, &$form) {
 
-} // */
+ // */
 
 /**
  * Implements hook_civicrm_navigationMenu().


### PR DESCRIPTION
Upgrading to current Civix version (`22.05.2`) for avoiding deprecation notices like `PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated`.

<details>
<summary>Complete command output</summary>
<pre>
$ civix upgrade

Incremental upgrades
====================

info.xml does not declare the civix format. Inferred v13.10.0.

Upgrade v13.10.0 => v16.10.0
----------------------------

Executing upgrade script civix/upgrades/16.10.0.up.php
Set civix format to 16.10.0 in info.xml
Write de.systopia.selfservice/info.xml

Upgrade v16.10.0 => v18.02.0
----------------------------

Executing upgrade script civix/upgrades/18.02.0.up.php
Set civix format to 18.02.0 in info.xml
Write de.systopia.selfservice/info.xml

Upgrade v18.02.0 => v19.06.2
----------------------------

Executing upgrade script civix/upgrades/19.06.2.up.php
Set civix format to 19.06.2 in info.xml
Write de.systopia.selfservice/info.xml

Upgrade v19.06.2 => v20.06.0
----------------------------

Executing upgrade script civix/upgrades/20.06.0.up.php
Set civix format to 20.06.0 in info.xml
Write de.systopia.selfservice/info.xml

Upgrade v20.06.0 => v22.05.0
----------------------------

Executing upgrade script civix/upgrades/22.05.0.up.php

 ! [NOTE] Civix v22.05 converts several functions to mixins. This reduces code-duplication and will enable easier       
 !        updates in the future.                                                                                        
 !                                                                                                                      
 !        The upgrader will examine your extension, remove old functions, and enable mixins (if needed).                
 !                                                                                                                      
 !        The following functions+mixins may be affected:                                                               
 !                                                                                                                      
 !        1. _*_civix_civicrm_angularModules()        =>  ang-php@1.0.0                                                 
 !        2. _*_civix_civicrm_managed()               =>  mgd-php@1.0.0                                                 
 !        3. _*_civix_civicrm_alterSettingsFolders()  =>  setting-php@1.0.0                                             
 !        4. _*_civix_civicrm_caseTypes()             =>  case-xml@1.0.0                                                
 !        5. _*_civix_civicrm_xmlMenu()               =>  menu-xml@1.0.0                                                
 !        6. _*_civix_civicrm_themes()                =>  theme-php@1.0.0                                               

 Continue with upgrade? (yes/no) [yes]:
 > 

 ! [NOTE] Skip "ang-php@1.0.0". There are no files matching pattern "glob:ang/*.ang.php".                               

 ! [NOTE] Skip "mgd-php@1.0.0". There are no files matching pattern "find:*.mgd.php".                                   

 ! [NOTE] Skip "setting-php@1.0.0". There are no files matching pattern "glob:settings/*.setting.php".                  

 ! [NOTE] Skip "case-xml@1.0.0". There are no files matching pattern "glob:xml/case/*.xml".                             

 ! [NOTE] Enable "menu-xml@1.0.0". There are files matching pattern "glob:xml/Menu/*.xml".                              

 ! [NOTE] Skip "theme-php@1.0.0". There are no files matching pattern "glob:*.theme.php".                               

Enable mixin menu-xml@1.0.0
Write de.systopia.selfservice/mixin/menu-xml@1.0.0.mixin.php
Write de.systopia.selfservice/mixin/polyfill.php
Write de.systopia.selfservice/info.xml
Found reference to obsolete function _selfservice_civix_civicrm_xmlMenu() at selfservice.php:99.

    97:  */
    98: function selfservice_civicrm_xmlMenu(&$files) {
*   99:   _selfservice_civix_civicrm_xmlMenu($files);
   100: }
   101: 
Removing line selfservice.php:99

Found reference to obsolete function _selfservice_civix_civicrm_managed() at selfservice.php:165.

   163:  */
   164: function selfservice_civicrm_managed(&$entities) {
*  165:   _selfservice_civix_civicrm_managed($entities);
   166: }
   167: 
Removing line selfservice.php:165

Found reference to obsolete function _selfservice_civix_civicrm_caseTypes() at selfservice.php:178.

   176:  */
   177: function selfservice_civicrm_caseTypes(&$caseTypes) {
*  178:   _selfservice_civix_civicrm_caseTypes($caseTypes);
   179: }
   180: 
Removing line selfservice.php:178

Found reference to obsolete function _selfservice_civix_civicrm_angularModules() at selfservice.php:192.

   190:  */
   191: function selfservice_civicrm_angularModules(&$angularModules) {
*  192:   _selfservice_civix_civicrm_angularModules($angularModules);
   193: }
   194: 
Removing line selfservice.php:192

Found reference to obsolete function _selfservice_civix_civicrm_alterSettingsFolders() at selfservice.php:201.

   199:  */
   200: function selfservice_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
*  201:   _selfservice_civix_civicrm_alterSettingsFolders($metaDataFolders);
   202: }
   203: 
Removing line selfservice.php:201

Found reference to obsolete function _selfservice_civix_civicrm_themes() at selfservice.php:219.

   217:  */
   218: function selfservice_civicrm_themes(&$themes) {
*  219:   _selfservice_civix_civicrm_themes($themes);
   220: }
   221: 
Removing line selfservice.php:219

Write de.systopia.selfservice/selfservice.php
Set civix format to 22.05.0 in info.xml
Write de.systopia.selfservice/info.xml

Upgrade v22.05.0 => v22.05.2
----------------------------

Executing upgrade script civix/upgrades/22.05.2.up.php
Set civix format to 22.05.2 in info.xml
Write de.systopia.selfservice/info.xml

General upgrade
===============


 ! [NOTE] The function "selfservice_civicrm_xmlMenu()" now appears to be empty.                                         

     1: /**
     2:  * Implements hook_civicrm_xmlMenu().
     3:  *
     4:  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
     5:  */
     6: function selfservice_civicrm_xmlMenu(&$files) {
     7: }
     8: 
     9: 

 Delete the empty function "selfservice_civicrm_xmlMenu()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "selfservice_civicrm_managed()" now appears to be empty.                                         

     1: /**
     2:  * Implements hook_civicrm_managed().
     3:  *
     4:  * Generate a list of entities to create/deactivate/delete when this module
     5:  * is installed, disabled, uninstalled.
     6:  *
     7:  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
     8:  */
     9: function selfservice_civicrm_managed(&$entities) {
    10: }
    11: 
    12: 

 Delete the empty function "selfservice_civicrm_managed()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "selfservice_civicrm_caseTypes()" now appears to be empty.                                       

     1: /**
     2:  * Implements hook_civicrm_caseTypes().
     3:  *
     4:  * Generate a list of case-types.
     5:  *
     6:  * Note: This hook only runs in CiviCRM 4.4+.
     7:  *
     8:  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
     9:  */
    10: function selfservice_civicrm_caseTypes(&$caseTypes) {
    11: }
    12: 
    13: 

 Delete the empty function "selfservice_civicrm_caseTypes()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "selfservice_civicrm_angularModules()" now appears to be empty.                                  

     1: /**
     2:  * Implements hook_civicrm_angularModules().
     3:  *
     4:  * Generate a list of Angular modules.
     5:  *
     6:  * Note: This hook only runs in CiviCRM 4.5+. It may
     7:  * use features only available in v4.6+.
     8:  *
     9:  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
    10:  */
    11: function selfservice_civicrm_angularModules(&$angularModules) {
    12: }
    13: 
    14: 

 Delete the empty function "selfservice_civicrm_angularModules()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "selfservice_civicrm_alterSettingsFolders()" now appears to be empty.                            

     1: /**
     2:  * Implements hook_civicrm_alterSettingsFolders().
     3:  *
     4:  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
     5:  */
     6: function selfservice_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
     7: }
     8: 
     9: 

 Delete the empty function "selfservice_civicrm_alterSettingsFolders()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "selfservice_civicrm_themes()" now appears to be empty.                                          

     1: /**
     2:  * Implements hook_civicrm_thems().
     3:  */
     4: function selfservice_civicrm_themes(&$themes) {
     5: }
     6: 
     7: 

 Delete the empty function "selfservice_civicrm_themes()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "selfservice_civicrm_preProcess()" now appears to be empty.                                      

     1: 
     2: function selfservice_civicrm_preProcess($formName, &$form) {
     3: 
     4: }

 Delete the empty function "selfservice_civicrm_preProcess()"? (yes/no) [yes]:
 > 

Write de.systopia.selfservice/selfservice.php
Write de.systopia.selfservice/info.xml
Write de.systopia.selfservice/selfservice.civix.php
</pre>
</details>