### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -14,11 +14,11 @@
     <url desc="Support">https://github.com/systopia/de.systopia.selfservice/issues</url>
     <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
   </urls>
-  <releaseDate></releaseDate>
+  <releaseDate/>
   <version>1.1.0-dev</version>
   <develStage>dev</develStage>
   <compatibility>
-    <ver>5.38</ver>
+    <ver>5.65</ver>
   </compatibility>
   <comments>This module is going back to efforts with AIVL and ProVeg</comments>
   <classloader>

--- a/templates/CRM/Selfservice/Form/Settings.tpl
+++ b/templates/CRM/Selfservice/Form/Settings.tpl
@@ -40,24 +40,24 @@
                 <a
                         class="action-item button crm-popup crm-small-popup"
                         href="{crmURL p="civicrm/admin/selfservice/profile" q="op=edit&name=$profile_name"}"
-                        title="{ts 1=$profile.name}Edit profile %1{/ts}"
+                        title="{ts escape='htmlattribute' 1=$profile.name}Edit profile %1{/ts}"
                 >{ts}Edit{/ts}</a>
                 <a
                         class="action-item button crm-popup crm-small-popup"
                         href="{crmURL p="civicrm/admin/selfservice/profile" q="op=copy&source_name=$profile_name"}"
-                        title="{ts 1=$profile.name}Copy profile %1{/ts}"
+                        title="{ts escape='htmlattribute' 1=$profile.name}Copy profile %1{/ts}"
                 >{ts}Copy{/ts}</a>
                   {if $profile_name == 'default'}
                     <a
                             class="action-item button crm-popup crm-small-popup"
                             href="{crmURL p="civicrm/admin/selfservice/profile" q="op=delete&name=$profile_name"}"
-                            title="{ts 1=$profile.name}Reset profile %1{/ts}"
+                            title="{ts escape='htmlattribute' 1=$profile.name}Reset profile %1{/ts}"
                     >{ts}Reset{/ts}</a>
                   {else}
                     <a
                             class="action-item button crm-popup crm-small-popup"
                             href="{crmURL p="civicrm/admin/selfservice/profile" q="op=delete&name=$profile_name"}"
-                            title="{ts 1=$profile.name}Delete profile %1{/ts}"
+                            title="{ts escape='htmlattribute' 1=$profile.name}Delete profile %1{/ts}"
                     >{ts}Delete{/ts}</a>
                   {/if}
 


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.