### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Selfservice/Form/SendLinkProfile.php
+++ b/CRM/Selfservice/Form/SendLinkProfile.php
@@ -241,7 +241,7 @@ class CRM_Selfservice_Form_SendLinkProfile extends CRM_Core_Form {
    * Get a list of eligible message templates
    *
    * @return array
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function getMessageTemplates(): array {
     $templates = ['' => E::ts("disabled")];

--- a/CRM/Selfservice/Form/Settings.php
+++ b/CRM/Selfservice/Form/Settings.php
@@ -139,7 +139,7 @@ class CRM_Selfservice_Form_Settings extends CRM_Core_Form {
    *
    * @return array
    *
-   * @throws \CiviCRM_API3_Exception
+   * @throws \CRM_Core_Exception
    */
   protected function getMessageTemplates() {
     $templates = ['' => E::ts("disabled")];


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.